### PR TITLE
[FE][Design] #7/ 헤더 및 푸터 반응형 구현

### DIFF
--- a/frontend/src/components/common/Button/index.tsx
+++ b/frontend/src/components/common/Button/index.tsx
@@ -21,7 +21,7 @@ Button.displayName = 'Button';
 const StyledButton = styled.button<{ $colorType: 'dark' | 'light' }>`
   width: 100px;
   padding: 1.2rem 1.2rem;
-  background-color: var(--primary-1);
+  background-color: var(--primary);
   color: ${({ $colorType }) =>
     $colorType === 'dark' ? 'var(--white)' : 'var(--black)'};
   font-size: 14px;

--- a/frontend/src/components/common/Header/index.tsx
+++ b/frontend/src/components/common/Header/index.tsx
@@ -2,10 +2,14 @@ import { memo } from 'react';
 import { styled } from 'styled-components';
 import Logo from '@assets/logo/dukpool-logo.svg';
 import Navbar from '../Navbar';
+import { media } from '@styles/media';
+import { Link } from 'react-router-dom';
 
 const Header = memo(() => (
   <StyledHeader>
-    <StyledLogo src={Logo} />
+    <Link to={'/'}>
+      <StyledLogo src={Logo} />
+    </Link>
     <Navbar />
   </StyledHeader>
 ));
@@ -23,6 +27,9 @@ const StyledHeader = styled.header`
   margin: 0 auto;
   background-color: white;
   box-shadow: 0px 0px 5px var(--gray-4);
+  ${media.tablet`
+  justify-content: center;
+  `}
 `;
 
 const StyledLogo = styled.img`

--- a/frontend/src/components/common/Layout/AuthLayout.tsx
+++ b/frontend/src/components/common/Layout/AuthLayout.tsx
@@ -1,5 +1,4 @@
 import { memo } from 'react';
-import styled from 'styled-components';
 
 type AuthLayoutProps = {
   children: React.ReactNode;
@@ -8,18 +7,9 @@ type AuthLayoutProps = {
 const AuthLayout = memo(({ children }: AuthLayoutProps) => {
   // 로그인 유무 처리
   // 비로그인 시 로그인 페이지로 이동
-  return <StyledAuthLayout>{children}</StyledAuthLayout>;
+  return <>{children}</>;
 });
 
 AuthLayout.displayName = 'AuthLayout';
-
-const StyledAuthLayout = styled.div`
-  display: flex;
-  flex-direction: column;
-  margin: 0px auto;
-  max-width: 1240px;
-  min-height: 100vh;
-  padding-top: 80px;
-`;
 
 export default AuthLayout;

--- a/frontend/src/components/common/Navbar/MobileNavbar.tsx
+++ b/frontend/src/components/common/Navbar/MobileNavbar.tsx
@@ -16,34 +16,34 @@ const MobileNavbar = memo(() => {
     <StyledNavbar>
       <StyledUl>
         <Link to="/">
-          <StyledList>
+          <StyledItem>
             <StyledLogo src={pathname === '/' ? FocusedHomeIcon : HomeIcon} />
             <p>홈</p>
-          </StyledList>
+          </StyledItem>
         </Link>
         <Link to="/article">
-          <StyledList>
+          <StyledItem>
             <StyledLogo
               src={pathname.includes('/article') ? FocusedEmojiIcon : EmojiIcon}
             />
             <p>덕질자랑</p>
-          </StyledList>
+          </StyledItem>
         </Link>
         <Link to="/talk">
-          <StyledList>
+          <StyledItem>
             <StyledLogo
               src={pathname.includes('/talk') ? FocusedCoffeeIcon : CoffeeIcon}
             />
             <p>덕질토크</p>
-          </StyledList>
+          </StyledItem>
         </Link>
         <Link to="/mypage">
-          <StyledList>
+          <StyledItem>
             <StyledLogo
               src={pathname.includes('/mypage') ? FocusedUserIcon : UserIcon}
             />
             <p>내정보</p>
-          </StyledList>
+          </StyledItem>
         </Link>
       </StyledUl>
     </StyledNavbar>
@@ -64,7 +64,7 @@ const StyledUl = styled.ul`
   justify-content: space-evenly;
 `;
 
-const StyledList = styled.li`
+const StyledItem = styled.li`
   display: flex;
   flex-direction: column;
   align-items: center;

--- a/frontend/src/components/common/Navbar/MobileNavbar.tsx
+++ b/frontend/src/components/common/Navbar/MobileNavbar.tsx
@@ -1,0 +1,80 @@
+import { memo } from 'react';
+import { Link, useLocation } from 'react-router-dom';
+import styled from 'styled-components';
+import HomeIcon from '@assets/icons/outlined-home.svg';
+import EmojiIcon from '@assets/icons/outlined-emoji.svg';
+import CoffeeIcon from '@assets/icons/outlined-coffee.svg';
+import UserIcon from '@assets/icons/outlined-user.svg';
+import FocusedHomeIcon from '@assets/icons/filled-home.svg';
+import FocusedEmojiIcon from '@assets/icons/filled-emoji.svg';
+import FocusedCoffeeIcon from '@assets/icons/filled-coffee.svg';
+import FocusedUserIcon from '@assets/icons/filled-user.svg';
+
+const MobileNavbar = memo(() => {
+  const { pathname } = useLocation();
+  return (
+    <StyledNavbar>
+      <StyledUl>
+        <Link to="/">
+          <StyledList>
+            <StyledLogo src={pathname === '/' ? FocusedHomeIcon : HomeIcon} />
+            <p>홈</p>
+          </StyledList>
+        </Link>
+        <Link to="/article">
+          <StyledList>
+            <StyledLogo
+              src={pathname.includes('/article') ? FocusedEmojiIcon : EmojiIcon}
+            />
+            <p>덕질자랑</p>
+          </StyledList>
+        </Link>
+        <Link to="/talk">
+          <StyledList>
+            <StyledLogo
+              src={pathname.includes('/talk') ? FocusedCoffeeIcon : CoffeeIcon}
+            />
+            <p>덕질토크</p>
+          </StyledList>
+        </Link>
+        <Link to="/mypage">
+          <StyledList>
+            <StyledLogo
+              src={pathname.includes('/mypage') ? FocusedUserIcon : UserIcon}
+            />
+            <p>내정보</p>
+          </StyledList>
+        </Link>
+      </StyledUl>
+    </StyledNavbar>
+  );
+});
+
+MobileNavbar.displayName = 'MobileNavbar';
+
+const StyledNavbar = styled.nav`
+  width: 100%;
+  position: fixed;
+  bottom: 0;
+  box-shadow: 0px 0px 5px var(--gray-4);
+`;
+
+const StyledUl = styled.ul`
+  display: flex;
+  justify-content: space-evenly;
+`;
+
+const StyledList = styled.li`
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  padding: 0.8rem 1.2rem;
+  font-size: 12px;
+`;
+
+const StyledLogo = styled.img`
+  width: 20px;
+  margin-bottom: 4px;
+`;
+
+export default MobileNavbar;

--- a/frontend/src/components/common/Navbar/index.tsx
+++ b/frontend/src/components/common/Navbar/index.tsx
@@ -1,26 +1,34 @@
 import { memo } from 'react';
-import { Link } from 'react-router-dom';
+import { Link, useLocation } from 'react-router-dom';
 import styled from 'styled-components';
 import { media } from '@styles/media';
 
 const Navbar = memo(() => {
   // 유저 로그인 유무 확인
+  const { pathname } = useLocation();
   return (
     <StyledNavbar>
       <StyledUl>
-        <StyledList>
-          <Link to="/">홈</Link>
-        </StyledList>
-        <StyledList>
-          <Link to="/article">덕질자랑</Link>
-        </StyledList>
-        <StyledList>
-          <Link to="/talk">덕질토크</Link>
-        </StyledList>
-        {/** 로그인 유무에 따라 로그인 또는 내정보 링크로 분기 */}
-        <StyledList>
-          <Link to="/mypage">내정보</Link>
-        </StyledList>
+        <Link to="/">
+          <StyledList $active={pathname === '/' ? true : false}>
+            <p>홈</p>
+          </StyledList>
+        </Link>
+        <Link to="/article">
+          <StyledList $active={pathname.includes('/article') ? true : false}>
+            <p>덕질자랑</p>
+          </StyledList>
+        </Link>
+        <Link to="/talk">
+          <StyledList $active={pathname.includes('/talk') ? true : false}>
+            <p>덕질토크</p>
+          </StyledList>
+        </Link>
+        <Link to="/mypage">
+          <StyledList $active={pathname.includes('/mypage') ? true : false}>
+            <p>내정보</p>
+          </StyledList>
+        </Link>
       </StyledUl>
     </StyledNavbar>
   );
@@ -38,8 +46,14 @@ const StyledUl = styled.ul`
   display: flex;
 `;
 
-const StyledList = styled.li`
-  padding: 1.2rem 2.4rem;
+const StyledList = styled.li<{ $active: boolean }>`
+  padding: 1.2rem 2rem;
+  background-color: ${({ $active }) =>
+    $active ? 'var(--primary-1)' : 'white'};
+  & > p {
+    color: ${({ $active }) => ($active ? 'var(--white)' : 'var(--black)')};
+  }
+  border-radius: 12px;
 `;
 
 export default Navbar;

--- a/frontend/src/components/common/Navbar/index.tsx
+++ b/frontend/src/components/common/Navbar/index.tsx
@@ -10,24 +10,24 @@ const Navbar = memo(() => {
     <StyledNavbar>
       <StyledUl>
         <Link to="/">
-          <StyledList $active={pathname === '/' ? true : false}>
+          <StyledItem $active={pathname === '/'}>
             <p>홈</p>
-          </StyledList>
+          </StyledItem>
         </Link>
         <Link to="/article">
-          <StyledList $active={pathname.includes('/article') ? true : false}>
+          <StyledItem $active={pathname.includes('/article')}>
             <p>덕질자랑</p>
-          </StyledList>
+          </StyledItem>
         </Link>
         <Link to="/talk">
-          <StyledList $active={pathname.includes('/talk') ? true : false}>
+          <StyledItem $active={pathname.includes('/talk')}>
             <p>덕질토크</p>
-          </StyledList>
+          </StyledItem>
         </Link>
         <Link to="/mypage">
-          <StyledList $active={pathname.includes('/mypage') ? true : false}>
+          <StyledItem $active={pathname.includes('/mypage')}>
             <p>내정보</p>
-          </StyledList>
+          </StyledItem>
         </Link>
       </StyledUl>
     </StyledNavbar>
@@ -46,7 +46,7 @@ const StyledUl = styled.ul`
   display: flex;
 `;
 
-const StyledList = styled.li<{ $active: boolean }>`
+const StyledItem = styled.li<{ $active: boolean }>`
   padding: 1.2rem 2rem;
   background-color: ${({ $active }) => ($active ? 'var(--primary)' : 'white')};
   & > p {

--- a/frontend/src/components/common/Navbar/index.tsx
+++ b/frontend/src/components/common/Navbar/index.tsx
@@ -48,8 +48,7 @@ const StyledUl = styled.ul`
 
 const StyledList = styled.li<{ $active: boolean }>`
   padding: 1.2rem 2rem;
-  background-color: ${({ $active }) =>
-    $active ? 'var(--primary-1)' : 'white'};
+  background-color: ${({ $active }) => ($active ? 'var(--primary)' : 'white')};
   & > p {
     color: ${({ $active }) => ($active ? 'var(--white)' : 'var(--black)')};
   }

--- a/frontend/src/hooks/useMediaQuery.ts
+++ b/frontend/src/hooks/useMediaQuery.ts
@@ -16,7 +16,6 @@ const useMediaQuery = (): { isMobile: boolean } => {
 
   function handleChange() {
     setMatches(getMatches(NON_DESKTOP_QUERY));
-    console.log('asdasd');
   }
 
   useEffect(() => {

--- a/frontend/src/pages/RootPage.tsx
+++ b/frontend/src/pages/RootPage.tsx
@@ -2,14 +2,17 @@ import { Outlet } from 'react-router-dom';
 import Header from '@components/common/Header';
 import Footer from '@components/common/Footer';
 import Layout from '@components/common/Layout';
+import useMediaQuery from '@hooks/useMediaQuery';
+import MobileNavbar from '@components/common/Navbar/MobileNavbar';
 const RootPage = () => {
+  const { isMobile } = useMediaQuery();
   return (
     <>
       <Header />
       <Layout>
         <Outlet />
       </Layout>
-      <Footer />
+      {isMobile ? <MobileNavbar /> : <Footer />}
     </>
   );
 };

--- a/frontend/src/pages/Talk.tsx
+++ b/frontend/src/pages/Talk.tsx
@@ -1,0 +1,5 @@
+const Talk = () => {
+  return <div>talk</div>;
+};
+
+export default Talk;

--- a/frontend/src/router.tsx
+++ b/frontend/src/router.tsx
@@ -7,6 +7,7 @@ import Home from '@pages/Home';
 import MyPage from '@pages/MyPage';
 import NotFound from '@pages/NotFound';
 import Search from '@pages/Search';
+import Talk from '@pages/Talk';
 
 type routeElement = {
   path: string;
@@ -22,9 +23,10 @@ const routes: routeElement[] = [
     errorElement: <NotFound />,
     children: [
       { path: '', element: <Home />, auth: false },
+      { path: 'article', element: <Article />, auth: false },
+      { path: 'talk', element: <Talk />, auth: false },
       { path: 'mypage', element: <MyPage />, auth: true },
       { path: 'search/:searchId', element: <Search />, auth: false },
-      { path: 'article', element: <Article />, auth: false },
     ],
   },
 ];

--- a/frontend/src/styles/base.ts
+++ b/frontend/src/styles/base.ts
@@ -2,10 +2,10 @@ import { css } from 'styled-components';
 
 const base = css`
   :root {
-    --primary-1: #25bc5d;
-    --primary-2: #74ad89;
+    --primary: #515ce6;
     --success: #3159b3;
     --error: #ba1e45;
+    --disabled: #828bed;
     --gray-1: #8e8e93;
     --gray-2: #aeaeb2;
     --gray-3: #c7c7cc;


### PR DESCRIPTION
close #7 

- 헤더와 푸터를 반응형으로 구현했습니다.
- tablet 사이즈 이하로는 푸터를 제외하고 하단에 navbar가 위치하도록 구현했습니다.
- navbar 내에서 pathname에 따른 분기 처리를 추가했습니다.

![Dec-07-2023 22-57-16](https://github.com/f-lab-edu/dukpool/assets/79186378/5ef98d45-abd8-451e-aede-f89055d58d54)
