### PR TITLE
[FE][Fix] #55/refresh 기능 수정

### DIFF
--- a/frontend/src/assets/icons/edit.svg
+++ b/frontend/src/assets/icons/edit.svg
@@ -1,0 +1,5 @@
+<svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M11 2H9C4 2 2 4 2 9V15C2 20 4 22 9 22H15C20 22 22 20 22 15V13" stroke="#292D32" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M16.0399 3.01976L8.15988 10.8998C7.85988 11.1998 7.55988 11.7898 7.49988 12.2198L7.06988 15.2298C6.90988 16.3198 7.67988 17.0798 8.76988 16.9298L11.7799 16.4998C12.1999 16.4398 12.7899 16.1398 13.0999 15.8398L20.9799 7.95976C22.3399 6.59976 22.9799 5.01976 20.9799 3.01976C18.9799 1.01976 17.3999 1.65976 16.0399 3.01976Z" stroke="#292D32" stroke-width="1.5" stroke-miterlimit="10" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M14.9102 4.1499C15.5802 6.5399 17.4502 8.4099 19.8502 9.0899" stroke="#292D32" stroke-width="1.5" stroke-miterlimit="10" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/frontend/src/components/article/ArticleCard/MyArticleCard.tsx
+++ b/frontend/src/components/article/ArticleCard/MyArticleCard.tsx
@@ -18,13 +18,19 @@ const MyArticleCard = memo(
       <StyledList>
         <StyledLink to={`/article/${data.id}`}>
           <StyledImgContainer>
-            <StyledImage src={data.img[0] ?? placeholderImage} />
+            <StyledImage
+              alt={data.title}
+              src={data.img[0] ?? placeholderImage}
+            />
           </StyledImgContainer>
           <StyledInfoContainer>
             <StyledTitle>{data.title}</StyledTitle>
             <StyledProfileContainer>
               <StyledProfileImageContainer>
-                <StyledProfileImage src={profileImg ?? placeholderImage} />
+                <StyledProfileImage
+                  alt={nickname}
+                  src={profileImg ?? placeholderImage}
+                />
               </StyledProfileImageContainer>
               <StyledProfile>{nickname}</StyledProfile>
             </StyledProfileContainer>

--- a/frontend/src/components/article/ArticleCard/index.tsx
+++ b/frontend/src/components/article/ArticleCard/index.tsx
@@ -20,13 +20,14 @@ const ArticleCard = memo(
       <StyledList>
         <StyledLink to={`/article/${id}`}>
           <StyledImgContainer>
-            <StyledImage src={img[0] ?? placeholderImage} />
+            <StyledImage alt={title} src={img[0] ?? placeholderImage} />
           </StyledImgContainer>
           <StyledInfoContainer>
             <StyledTitle>{title}</StyledTitle>
             <StyledProfileContainer>
               <StyledProfileImageContainer>
                 <StyledProfileImage
+                  alt={writer.nickname}
                   src={writer.profileImg ?? placeholderImage}
                 />
               </StyledProfileImageContainer>

--- a/frontend/src/components/article/ArticleDetail/ArticleCommentItem.tsx
+++ b/frontend/src/components/article/ArticleDetail/ArticleCommentItem.tsx
@@ -52,6 +52,7 @@ const ArticleCommentItem = memo(
             <StyledCommentUserProfileContainer>
               <StyledCommentProfileImgContainer>
                 <StyledCommentProfileImg
+                  alt={writer.nickname}
                   src={writer.profileImg ?? placeholderImage}
                 />
               </StyledCommentProfileImgContainer>

--- a/frontend/src/components/article/ArticleDetail/ArticleDescription.tsx
+++ b/frontend/src/components/article/ArticleDetail/ArticleDescription.tsx
@@ -49,7 +49,10 @@ const ArticleDescription = memo(
           <StyledUserProfileContainer>
             <StyledUserProfile>
               <StyledProfileImgContainer>
-                <StyledProfileImg src={writer.profileImg ?? placeholderImage} />
+                <StyledProfileImg
+                  alt={writer.nickname}
+                  src={writer.profileImg ?? placeholderImage}
+                />
               </StyledProfileImgContainer>
               <StyledProfileName>{writer.nickname}</StyledProfileName>
             </StyledUserProfile>

--- a/frontend/src/components/article/ArticleDetail/index.tsx
+++ b/frontend/src/components/article/ArticleDetail/index.tsx
@@ -12,7 +12,7 @@ const ArticleDetail = () => {
   const { data } = useArticle(articleId);
   return (
     <StyledArticle>
-      <PostImage images={data.img} />
+      <PostImage title={data.title} images={data.img} />
       <ArticleDescription {...data} />
       <ArticleComment contentId={data.id} comments={data.comment} />
     </StyledArticle>

--- a/frontend/src/components/article/EditArticle/DukpoolEditArticle.tsx
+++ b/frontend/src/components/article/EditArticle/DukpoolEditArticle.tsx
@@ -65,10 +65,10 @@ const DukpoolEditArticle = memo(() => {
           placeholder="제목을 입력해주세요."
           registerType="title"
           required={true}
-          minLength={5}
+          minLength={2}
         />
         {titleErrorState && (
-          <ErrorMessage field="제목" type={titleErrorState.type} length={5} />
+          <ErrorMessage field="제목" type={titleErrorState.type} length={2} />
         )}
         <Tags />
         <TextArea
@@ -84,12 +84,7 @@ const DukpoolEditArticle = memo(() => {
         <Images />
         <StyledButtonContainer>
           <StyledButtonWrapper>
-            <Button
-              type="submit"
-              text="등록"
-              disabled={false}
-              $colorType="dark"
-            />
+            <Button type="submit" text="등록" disabled={false} />
           </StyledButtonWrapper>
         </StyledButtonContainer>
       </form>

--- a/frontend/src/components/common/Button/KakaoLoginButton.tsx
+++ b/frontend/src/components/common/Button/KakaoLoginButton.tsx
@@ -12,7 +12,7 @@ const KakaoLoginButton = memo(() => {
     <StyledLink
       to={`https://kauth.kakao.com/oauth/authorize?client_id=${CONFIG.API_KEYS.LOGIN}&redirect_uri=${REDIRECT_URI}/api/auth/kakao/callback&response_type=code`}
     >
-      <StyledKakaoLogo src={KakaoLogo} />
+      <StyledKakaoLogo alt="kakao logo" src={KakaoLogo} />
       <StyledInfoText>카카오 로그인</StyledInfoText>
     </StyledLink>
   );

--- a/frontend/src/components/common/Button/LikeButton.tsx
+++ b/frontend/src/components/common/Button/LikeButton.tsx
@@ -13,7 +13,7 @@ const LikeButton = memo(({ onClick, likeCount, isLiked }: ButtonProps) => {
   return (
     <StyledButtonContainer>
       <StyledButton type="button" onClick={onClick}>
-        <StyledLogo src={isLiked ? ActivelikeIcon : likeIcon} />
+        <StyledLogo alt="like" src={isLiked ? ActivelikeIcon : likeIcon} />
         <StyledCount>{likeCount}</StyledCount>
       </StyledButton>
     </StyledButtonContainer>

--- a/frontend/src/components/common/Button/index.tsx
+++ b/frontend/src/components/common/Button/index.tsx
@@ -4,8 +4,7 @@ import styled from 'styled-components';
 type ButtonProps = React.HTMLAttributes<HTMLButtonElement> & {
   text: string;
   disabled: boolean;
-  $colorType: 'dark' | 'light';
-  error?: boolean;
+  $colorType?: 'primary' | 'light' | 'error';
   type?: 'button' | 'submit';
   onClick?: React.MouseEventHandler<HTMLButtonElement>;
 };
@@ -15,8 +14,7 @@ const Button = memo(
     text,
     disabled,
     onClick,
-    $colorType,
-    error,
+    $colorType = 'primary',
     type = 'button',
   }: ButtonProps) => {
     return (
@@ -25,7 +23,6 @@ const Button = memo(
         onClick={onClick}
         disabled={disabled}
         $colorType={$colorType}
-        $error={error}
       >
         {text}
       </StyledButton>
@@ -36,27 +33,36 @@ const Button = memo(
 Button.displayName = 'Button';
 
 const StyledButton = styled.button<{
-  $colorType: 'dark' | 'light';
-  $error?: boolean;
+  $colorType: 'primary' | 'light' | 'error';
 }>`
   width: 100%;
   max-width: 400px;
   padding: 0.8rem 1.2rem;
-  background-color: ${({ $colorType, $error }) =>
-    $error
-      ? 'var(--error)'
-      : $colorType === 'dark'
-        ? 'var(--primary)'
-        : 'var(--gray-5)'};
-  color: ${({ $colorType }) =>
-    $colorType === 'dark' ? 'var(--white)' : 'var(--black)'};
+  background-color: ${({ $colorType }) => {
+    switch ($colorType) {
+      case 'primary':
+        return 'var(--primary)';
+      case 'light':
+        return 'var(--gray-5)';
+      case 'error':
+        return 'var(--error)';
+    }
+  }};
+  color: ${({ $colorType }) => {
+    switch ($colorType) {
+      case 'light':
+        return 'var(--black)';
+      default:
+        return 'var(--white)';
+    }
+  }};
   font-size: 14px;
   font-weight: 500;
   border: none;
   border-radius: 12px;
   &:disabled {
     background-color: ${({ $colorType }) =>
-      $colorType === 'dark' ? 'gray' : 'black'};
+      $colorType === 'primary' ? 'gray' : 'black'};
   }
 `;
 

--- a/frontend/src/components/common/Dropdown/index.tsx
+++ b/frontend/src/components/common/Dropdown/index.tsx
@@ -6,8 +6,8 @@ import downArrow from '@assets/icons/arrow-down.svg';
 
 const DROPDOWN_OPTIONS = [
   { type: '', name: '최신순' },
-  { type: 'like', name: '좋아요 많은 순' },
-  { type: 'commentcount', name: '댓글 많은 순' },
+  { type: 'like', name: '좋아요순' },
+  { type: 'commentcount', name: '댓글순' },
 ];
 
 const Dropdown = memo(
@@ -33,7 +33,7 @@ const Dropdown = memo(
       <StyledWrapper ref={dropdownRef}>
         <StyledDropdownBtn onClick={toggleDropdown}>
           <StyledSortOption>{currentSortType(sortType)}</StyledSortOption>
-          <StyledArrow src={isOpen ? upArrow : downArrow} />
+          <StyledArrow alt="arrow" src={isOpen ? upArrow : downArrow} />
         </StyledDropdownBtn>
         {isOpen && (
           <DropdownMenu>

--- a/frontend/src/components/common/ErrorFallback/index.tsx
+++ b/frontend/src/components/common/ErrorFallback/index.tsx
@@ -1,4 +1,4 @@
-import { memo, useEffect } from 'react';
+import { memo, useContext, useEffect } from 'react';
 import { FallbackProps } from 'react-error-boundary';
 import { useNavigate } from 'react-router-dom';
 import useMediaQuery from '@hooks/useMediaQuery';
@@ -9,21 +9,29 @@ import Layout from '@components/common/Layout';
 import MobileNavbar from '@components/common/Navbar/MobileNavbar';
 import Footer from '@components/common/Footer';
 import Logo from '@assets/logo/dukpool-logo.svg';
-import { UnAuthorizedError } from '@utils/errors';
+import { UnAuthorizedError, ExpiredRefreshTokenError } from '@utils/errors';
 import useInnerHeight from '@hooks/useInnerHeight';
+import { ToastContext } from '@context/ToastContext';
 
 const ErrorFallback = memo(({ error, resetErrorBoundary }: FallbackProps) => {
   const { height } = useInnerHeight();
   const { isMobile } = useMediaQuery();
   const navigate = useNavigate();
+  const { showToast } = useContext(ToastContext);
+
   useEffect(() => {
     if (error instanceof UnAuthorizedError) {
       navigate('/login');
       resetErrorBoundary();
     }
+    if (error instanceof ExpiredRefreshTokenError) {
+      showToast('토큰이 만료되었습니다. 다시 로그인해주세요');
+      resetErrorBoundary();
+    }
   }, []);
 
   if (error instanceof UnAuthorizedError) return null;
+  if (error instanceof ExpiredRefreshTokenError) return null;
 
   return (
     <>
@@ -31,7 +39,7 @@ const ErrorFallback = memo(({ error, resetErrorBoundary }: FallbackProps) => {
       <Layout>
         <StyledWrapper $height={height}>
           <StyledInfo>
-            <StyledLogo src={Logo} alt="Dukpool 로고" />
+            <StyledLogo src={Logo} alt="Dukpool Logo" />
             <StyledParagraph>
               데이터를 불러오는데 오류가 발생했습니다.
             </StyledParagraph>
@@ -40,7 +48,6 @@ const ErrorFallback = memo(({ error, resetErrorBoundary }: FallbackProps) => {
           <Button
             text="재시도"
             disabled={false}
-            $colorType="dark"
             onClick={resetErrorBoundary}
           ></Button>
         </StyledWrapper>

--- a/frontend/src/components/common/Footer/index.tsx
+++ b/frontend/src/components/common/Footer/index.tsx
@@ -14,7 +14,7 @@ const Footer = memo(() => (
         <p>COPYRIGHT © 2023 DUKPOOL ALL RIGHTS RESERVED</p>
       </div>
       <Link target="_blank" to="https://github.com/f-lab-edu/dukpool">
-        <StyledLogo src={GithubLogo} />
+        <StyledLogo alt="github logo" src={GithubLogo} />
       </Link>
     </StyledLine>
   </StyledFooter>

--- a/frontend/src/components/common/Form/Images.tsx
+++ b/frontend/src/components/common/Form/Images.tsx
@@ -29,9 +29,9 @@ const Images = memo(() => {
       <StyledContainer>
         <label htmlFor="fileImage">
           <StyledCustomInput>
-            <StyledCameraImg src={cameraIcon} />
+            <StyledCameraImg alt="camera" src={cameraIcon} />
             <StyledTopContainer>
-              <StyledTopImg src={plusIcon} />
+              <StyledTopImg alt="add" src={plusIcon} />
             </StyledTopContainer>
           </StyledCustomInput>
         </label>

--- a/frontend/src/components/common/Form/Tags.tsx
+++ b/frontend/src/components/common/Form/Tags.tsx
@@ -17,7 +17,7 @@ const Tags = memo(() => {
     const target = event.target as HTMLInputElement;
     if (
       target.value.length &&
-      event.key === ' ' &&
+      event.key === 'Enter' &&
       !currentTags.includes(target.value) &&
       !event.nativeEvent.isComposing
     ) {
@@ -37,8 +37,8 @@ const Tags = memo(() => {
           }
           type="text"
           value={tagItem}
-          onKeyUp={onKeyPress}
-          placeholder="스페이스바를 눌러 관련있는 태그를 추가해보세요."
+          onKeyDown={onKeyPress}
+          placeholder="Enter를 눌러 관련있는 태그를 추가해보세요."
         />
         <StyledTagsContainer>
           {currentTags.map((tag) => (

--- a/frontend/src/components/common/Header/index.tsx
+++ b/frontend/src/components/common/Header/index.tsx
@@ -8,7 +8,7 @@ import { Link } from 'react-router-dom';
 const Header = memo(() => (
   <StyledHeader>
     <Link to={'/'}>
-      <StyledLogo src={Logo} />
+      <StyledLogo alt="Dukpool Logo" src={Logo} />
     </Link>
     <Navbar />
   </StyledHeader>

--- a/frontend/src/components/common/Modal/CommentModal.tsx
+++ b/frontend/src/components/common/Modal/CommentModal.tsx
@@ -16,13 +16,14 @@ const CommentModal = memo(({ onSubmit, onAbort }: ModalProps) => {
       <StyledContainer>
         <StyledCloseBtnContainer>
           <StyledCloseIcon
+            alt="close"
             src={closeIcon}
             onClick={() => onAbort?.(new Error())}
           />
         </StyledCloseBtnContainer>
         <StyledFlexContainer>
           <StyledLogoContainer>
-            <StyledLogo src={alert} />
+            <StyledLogo alt="alert" src={alert} />
           </StyledLogoContainer>
           <StyledSpan>작성하신 댓글을 삭제하시겠어요?</StyledSpan>
           <StyledButtonContainer>
@@ -36,8 +37,7 @@ const CommentModal = memo(({ onSubmit, onAbort }: ModalProps) => {
               text="삭제"
               disabled={false}
               onClick={() => onSubmit?.(true)}
-              $colorType="dark"
-              error={true}
+              $colorType="error"
             />
           </StyledButtonContainer>
         </StyledFlexContainer>

--- a/frontend/src/components/common/Modal/LoginModal.tsx
+++ b/frontend/src/components/common/Modal/LoginModal.tsx
@@ -16,13 +16,14 @@ const LoginModal = memo(({ onSubmit, onAbort }: ModalProps) => {
       <StyledContainer>
         <StyledCloseBtnContainer>
           <StyledCloseIcon
+            alt="close"
             src={closeIcon}
             onClick={() => onAbort?.(new Error())}
           />
         </StyledCloseBtnContainer>
         <StyledFlexContainer>
           <StyledLogoContainer>
-            <StyledLogo src={logo} />
+            <StyledLogo alt="alert" src={logo} />
           </StyledLogoContainer>
           <StyledSpan>로그인 후에 이용해보세요!</StyledSpan>
           <StyledButtonContainer onClick={() => onSubmit?.(true)}>

--- a/frontend/src/components/common/Modal/PostModal.tsx
+++ b/frontend/src/components/common/Modal/PostModal.tsx
@@ -16,13 +16,14 @@ const PostModal = memo(({ onSubmit, onAbort }: ModalProps) => {
       <StyledContainer>
         <StyledCloseBtnContainer>
           <StyledCloseIcon
+            alt="close"
             src={closeIcon}
             onClick={() => onAbort?.(new Error())}
           />
         </StyledCloseBtnContainer>
         <StyledFlexContainer>
           <StyledLogoContainer>
-            <StyledLogo src={alert} />
+            <StyledLogo alt="alert" src={alert} />
           </StyledLogoContainer>
           <StyledSpan>작성하신 게시물을 삭제하시겠어요?</StyledSpan>
           <StyledButtonContainer>
@@ -36,8 +37,7 @@ const PostModal = memo(({ onSubmit, onAbort }: ModalProps) => {
               text="삭제"
               disabled={false}
               onClick={() => onSubmit?.(true)}
-              $colorType="dark"
-              error={true}
+              $colorType="error"
             />
           </StyledButtonContainer>
         </StyledFlexContainer>

--- a/frontend/src/components/common/Modal/ResignModal.tsx
+++ b/frontend/src/components/common/Modal/ResignModal.tsx
@@ -16,13 +16,14 @@ const ResignModal = memo(({ onSubmit, onAbort }: ModalProps) => {
       <StyledContainer>
         <StyledCloseBtnContainer>
           <StyledCloseIcon
+            alt="close"
             src={closeIcon}
             onClick={() => onAbort?.(new Error())}
           />
         </StyledCloseBtnContainer>
         <StyledFlexContainer>
           <StyledLogoContainer>
-            <StyledLogo src={alert} />
+            <StyledLogo alt="alert" src={alert} />
           </StyledLogoContainer>
           <StyledSpan>정말 덕풀 계정을 삭제하시겠어요?</StyledSpan>
           <StyledButtonContainer>
@@ -36,8 +37,7 @@ const ResignModal = memo(({ onSubmit, onAbort }: ModalProps) => {
               text="삭제"
               disabled={false}
               onClick={() => onSubmit?.(true)}
-              $colorType="dark"
-              error={true}
+              $colorType="error"
             />
           </StyledButtonContainer>
         </StyledFlexContainer>

--- a/frontend/src/components/common/Navbar/MobileNavbar.tsx
+++ b/frontend/src/components/common/Navbar/MobileNavbar.tsx
@@ -18,36 +18,46 @@ const MobileNavbar = memo(() => {
   return (
     <StyledNavbar>
       <StyledUl>
-        <Link to="/">
-          <StyledItem>
-            <StyledLogo src={pathname === '/' ? FocusedHomeIcon : HomeIcon} />
-            <p>홈</p>
-          </StyledItem>
-        </Link>
-        <Link to="/article">
-          <StyledItem>
+        <StyledItem>
+          <Link to="/">
             <StyledLogo
+              alt="홈"
+              src={pathname === '/' ? FocusedHomeIcon : HomeIcon}
+            />
+            <p>홈</p>
+          </Link>
+        </StyledItem>
+        <StyledItem>
+          <Link to="/article">
+            <StyledLogo
+              alt="덕질자랑"
               src={pathname.includes('/article') ? FocusedEmojiIcon : EmojiIcon}
             />
             <p>덕질자랑</p>
-          </StyledItem>
-        </Link>
-        <Link to="/talk">
-          <StyledItem>
+          </Link>
+        </StyledItem>
+        <StyledItem>
+          <Link to="/talk">
             <StyledLogo
+              alt="덕질토크"
               src={pathname.includes('/talk') ? FocusedCoffeeIcon : CoffeeIcon}
             />
             <p>덕질토크</p>
-          </StyledItem>
-        </Link>
-        <Link to="/mypage">
-          <StyledItem>
+          </Link>
+        </StyledItem>
+        <StyledItem>
+          <Link to={isLoggined ? '/mypage' : '/login'}>
             <StyledLogo
-              src={pathname.includes('/mypage') ? FocusedUserIcon : UserIcon}
+              alt="유저"
+              src={
+                pathname.includes('/mypage') || pathname.includes('/login')
+                  ? FocusedUserIcon
+                  : UserIcon
+              }
             />
             <p>{isLoggined ? '내정보' : '로그인'}</p>
-          </StyledItem>
-        </Link>
+          </Link>
+        </StyledItem>
       </StyledUl>
     </StyledNavbar>
   );
@@ -74,6 +84,7 @@ const StyledItem = styled.li`
   align-items: center;
   padding: 0.8rem 1.2rem;
   font-size: 10px;
+  text-align: center;
 `;
 
 const StyledLogo = styled.img`

--- a/frontend/src/components/common/Navbar/index.tsx
+++ b/frontend/src/components/common/Navbar/index.tsx
@@ -11,26 +11,28 @@ const Navbar = memo(() => {
   return (
     <StyledNavbar>
       <StyledUl>
-        <Link to="/">
-          <StyledItem $active={pathname === '/'}>
+        <StyledItem $active={pathname === '/'}>
+          <Link to="/">
             <p>홈</p>
-          </StyledItem>
-        </Link>
-        <Link to="/article">
-          <StyledItem $active={pathname.includes('/article')}>
+          </Link>
+        </StyledItem>
+        <StyledItem $active={pathname.includes('/article')}>
+          <Link to="/article">
             <p>덕질자랑</p>
-          </StyledItem>
-        </Link>
-        <Link to="/talk">
-          <StyledItem $active={pathname.includes('/talk')}>
+          </Link>
+        </StyledItem>
+        <StyledItem $active={pathname.includes('/talk')}>
+          <Link to="/talk">
             <p>덕질토크</p>
-          </StyledItem>
-        </Link>
-        <Link to="/mypage">
-          <StyledItem $active={pathname.includes('/mypage')}>
+          </Link>
+        </StyledItem>
+        <StyledItem
+          $active={pathname.includes('/mypage') || pathname.includes('/login')}
+        >
+          <Link to={isLoggined ? '/mypage' : '/login'}>
             <p>{isLoggined ? '내정보' : '로그인'}</p>
-          </StyledItem>
-        </Link>
+          </Link>
+        </StyledItem>
       </StyledUl>
     </StyledNavbar>
   );
@@ -51,10 +53,13 @@ const StyledUl = styled.ul`
 const StyledItem = styled.li<{ $active: boolean }>`
   padding: 1.2rem 2rem;
   background-color: ${({ $active }) => ($active ? 'var(--primary)' : 'white')};
-  & > p {
+  & > a > p {
     color: ${({ $active }) => ($active ? 'var(--white)' : 'var(--black)')};
   }
   border-radius: 12px;
 `;
+
+// const StyledSpan = styled.span`
+// `
 
 export default Navbar;

--- a/frontend/src/components/common/PostDetail/CommentInput.tsx
+++ b/frontend/src/components/common/PostDetail/CommentInput.tsx
@@ -40,7 +40,6 @@ const CommentInput = memo(
               type="submit"
               text={buttonText}
               disabled={userUniqId ? false : true}
-              $colorType="dark"
             />
           </StyledButtonWrapper>
         </StyledButtonContainer>

--- a/frontend/src/components/common/PostDetail/PostImage.tsx
+++ b/frontend/src/components/common/PostDetail/PostImage.tsx
@@ -5,27 +5,29 @@ import { ArticleImageSliderOption } from '@constants/sliderOption';
 import placeholderImage from '@assets/images/placeholder-image.png';
 import { media } from '@styles/media';
 
-const PostImage = memo(({ images }: { images: string[] }) => {
-  return (
-    <StyledWrapper>
-      <StyledContainer>
-        <StyledSlider {...ArticleImageSliderOption}>
-          {images.length ? (
-            images.map((image) => (
-              <StyledImgContainer key={image}>
-                <StyledImg src={image} />
+const PostImage = memo(
+  ({ title, images }: { title: string; images: string[] }) => {
+    return (
+      <StyledWrapper>
+        <StyledContainer>
+          <StyledSlider {...ArticleImageSliderOption}>
+            {images.length ? (
+              images.map((image, idx) => (
+                <StyledImgContainer key={image}>
+                  <StyledImg alt={`${title} ${idx + 1}`} src={image} />
+                </StyledImgContainer>
+              ))
+            ) : (
+              <StyledImgContainer>
+                <StyledImg src={placeholderImage} />
               </StyledImgContainer>
-            ))
-          ) : (
-            <StyledImgContainer>
-              <StyledImg src={placeholderImage} />
-            </StyledImgContainer>
-          )}
-        </StyledSlider>
-      </StyledContainer>
-    </StyledWrapper>
-  );
-});
+            )}
+          </StyledSlider>
+        </StyledContainer>
+      </StyledWrapper>
+    );
+  },
+);
 
 PostImage.displayName = 'PostImage';
 

--- a/frontend/src/components/common/SearchBar/index.tsx
+++ b/frontend/src/components/common/SearchBar/index.tsx
@@ -36,11 +36,12 @@ const SearchBar = memo(() => {
       />
       {searchText && (
         <StyledBtn type="button" onClick={() => dispatch({ type: 'clear' })}>
-          <img src={closeIcon} />
+          <img alt="clear" src={closeIcon} />
         </StyledBtn>
       )}
       {searchData && isFocused && (
         <PreviewList
+          searchText={debouncedSearchText}
           contents={searchData.contents.data}
           talkContents={searchData.talkContents.data}
         />

--- a/frontend/src/components/common/Skeleton/ArticleCardSkeleton.tsx
+++ b/frontend/src/components/common/Skeleton/ArticleCardSkeleton.tsx
@@ -8,7 +8,7 @@ const ArticleCardSkeleton = memo(() => {
     <SkeletonList>
       <SkeletonContainer>
         <SkeletonImgContainer>
-          <SkeletonImage src={placeholderImage} />
+          <SkeletonImage alt="placeholderImage" src={placeholderImage} />
         </SkeletonImgContainer>
         <SkeletonInfoContainer>
           <SkeletonTitle />

--- a/frontend/src/components/common/Skeleton/ArticlePostSkeleton.tsx
+++ b/frontend/src/components/common/Skeleton/ArticlePostSkeleton.tsx
@@ -12,7 +12,7 @@ const ArticlePostSkeleton = memo(() => {
         <SkeletonContainer>
           <SkeletonSlider {...ArticleImageSliderOption}>
             <SkeletonImgContainer>
-              <StyledImg src={placeholderImage} />
+              <StyledImg alt="placeholderImage" src={placeholderImage} />
             </SkeletonImgContainer>
           </SkeletonSlider>
         </SkeletonContainer>
@@ -21,7 +21,10 @@ const ArticlePostSkeleton = memo(() => {
         <SkeletonInfoContainer>
           <SkeletonUserProfile>
             <SkeletonProfileImgContainer>
-              <SkeletonProfileImg src={placeholderImage} />
+              <SkeletonProfileImg
+                alt="placeholderImage"
+                src={placeholderImage}
+              />
             </SkeletonProfileImgContainer>
             <SkeletonProfileName />
           </SkeletonUserProfile>

--- a/frontend/src/components/common/Skeleton/MyInfoSkeleton.tsx
+++ b/frontend/src/components/common/Skeleton/MyInfoSkeleton.tsx
@@ -11,8 +11,8 @@ const MyInfoSkeleton = memo(() => {
       <SkeletonSection>
         <SkeletonTitle />
         <SkeletonContainer>
-          <StyledImg src={placeholderImage} />
-          <SkeletonInputContainer />
+          <StyledImg alt="placeholderImage" src={placeholderImage} />
+          <SkeletonInfoContainer />
         </SkeletonContainer>
       </SkeletonSection>
       <SkeletonSection>
@@ -69,18 +69,16 @@ const SkeletonPostContainer = styled.div`
 `;
 
 const StyledImg = styled.img`
-  max-width: 160px;
+  width: 100px;
+  height: 100px;
   overflow: hidden;
   border-radius: 50%;
   aspect-ratio: 1;
 `;
 
-const SkeletonInputContainer = styled.div`
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  justify-content: center;
-  width: 70%;
+const SkeletonInfoContainer = styled.div`
+  width: 200px;
+  height: 100px;
   border-radius: 8px;
   background-color: var(--skeleton);
 `;

--- a/frontend/src/components/common/Skeleton/TalkCardSkeleton.tsx
+++ b/frontend/src/components/common/Skeleton/TalkCardSkeleton.tsx
@@ -8,7 +8,7 @@ const TalkCardSkeleton = memo(() => {
       <SkeletonWrapper>
         <SkeletonContainer>
           <SkeletonImgContainer>
-            <SkeletonImage src={placeholderImage} />
+            <SkeletonImage alt="placeholderImage" src={placeholderImage} />
           </SkeletonImgContainer>
           <SkeletonContentContainer>
             <SkeletonTitle />
@@ -87,14 +87,14 @@ const SkeletonContentContainer = styled.div`
 
 const SkeletonContent = styled.div`
   width: 100%;
-  height: 13px;
+  height: 12px;
   line-height: 1.36;
   background-color: var(--skeleton);
   border-radius: 8px;
 `;
 
 const SkeletonTitle = styled.div`
-  height: 18px;
+  height: 16px;
   margin-bottom: 8px;
   background-color: var(--skeleton);
   border-radius: 8px;

--- a/frontend/src/components/common/Tag/index.tsx
+++ b/frontend/src/components/common/Tag/index.tsx
@@ -14,7 +14,7 @@ const Tag = ({ tagName, buttonHandler }: tagProps) => {
         <>
           <StyledTagName>#{tagName}</StyledTagName>
           <StyledButton type="button" onClick={buttonHandler}>
-            <StyledImg src={closeIcon} alt="삭제" />
+            <StyledImg src={closeIcon} alt="close" />
           </StyledButton>
         </>
       ) : (

--- a/frontend/src/components/mypage/MyInfo.tsx
+++ b/frontend/src/components/mypage/MyInfo.tsx
@@ -1,126 +1,23 @@
 import { memo } from 'react';
-import { FormProvider, useForm } from 'react-hook-form';
-import { useCheckNickname, useUserData } from '@hooks/useGetQueries';
-import { usePatchNickname } from '@hooks/usePatchMutations';
-import { media } from '@styles/media';
-import styled from 'styled-components';
-import useDebounce from '@hooks/useDebounce';
-import Input from '@components/common/Input';
-import Button from '@components/common/Button';
-import placeholderImage from '@assets/images/placeholder-image.png';
+import { useUserData } from '@hooks/useGetQueries';
 import MyPosts from '@components/mypage/MyPosts';
-import ErrorMessage from '@components/common/ErrorMessage.tsx';
-
-type FormValue = {
-  nickname: string;
-};
+import MyProfile from '@components/mypage/MyProfile';
 
 const MyInfo = memo(() => {
   const { data: user } = useUserData();
-  const methods = useForm<FormValue>({
-    defaultValues: {
-      nickname: user.nickname,
-    },
-    mode: 'onTouched',
-  });
-  const nickname = methods.watch('nickname');
-  const debouncedNickname = useDebounce(nickname, 200);
-  const { data: validate } = useCheckNickname(debouncedNickname, user.nickname);
-  const { mutate: updateNickname } = usePatchNickname();
-  const onSubmit = ({ nickname }: FormValue) => {
-    if (!validate) updateNickname(nickname);
-  };
   return (
-    <FormProvider {...methods}>
-      <StyledSection>
-        <StyledSectionTitle>유저 정보</StyledSectionTitle>
-        <StyledContainer>
-          <StyledImg src={user.profileImg ?? placeholderImage} />
-          <StyledForm onSubmit={methods.handleSubmit(onSubmit)}>
-            <Input
-              label="닉네임"
-              placeholder="닉네임을 입력해주세요."
-              registerType="nickname"
-              required={true}
-              maxLength={8}
-            />
-            {validate && nickname !== user.nickname ? (
-              <ErrorMessage type="duplicate" />
-            ) : null}
-            <StyledButtonContainer>
-              <StyledButtonWrapper>
-                <Button
-                  type="submit"
-                  text="수정"
-                  disabled={
-                    nickname === user.nickname ||
-                    validate ||
-                    nickname.length < 2
-                  }
-                  $colorType="dark"
-                />
-              </StyledButtonWrapper>
-            </StyledButtonContainer>
-          </StyledForm>
-        </StyledContainer>
-      </StyledSection>
+    <>
+      <MyProfile profileImg={user.profileImg} nickname={user.nickname} />
       <MyPosts
         userNickname={user.nickname}
         userProfile={user.profileImg}
         articles={user.content}
         talks={user.talkContent}
       />
-    </FormProvider>
+    </>
   );
 });
 
 MyInfo.displayName = 'MyInfo';
-
-const StyledSection = styled.section`
-  max-width: 1140px;
-  width: 100%;
-  padding: 0 50px;
-  margin: 40px auto;
-  ${media.phone`
-    padding: 0 20px;
-  `}
-`;
-
-const StyledSectionTitle = styled.h2`
-  font-weight: bold;
-  font-size: 20px;
-  margin-bottom: 20px;
-`;
-
-const StyledContainer = styled.div`
-  display: flex;
-  justify-content: center;
-  gap: 15px;
-`;
-
-const StyledImg = styled.img`
-  max-width: 160px;
-  overflow: hidden;
-  border-radius: 50%;
-  aspect-ratio: 1;
-`;
-
-const StyledForm = styled.form`
-  display: flex;
-  flex-direction: column;
-  justify-content: center;
-  width: 70%;
-`;
-
-const StyledButtonContainer = styled.div`
-  margin-top: 12px;
-  width: 100%;
-  display: flex;
-  justify-content: flex-end;
-`;
-
-const StyledButtonWrapper = styled.div`
-  width: 100px;
-`;
 
 export default MyInfo;

--- a/frontend/src/components/mypage/MyProfile.tsx
+++ b/frontend/src/components/mypage/MyProfile.tsx
@@ -1,0 +1,195 @@
+import { memo, useContext, useState } from 'react';
+import { FormProvider, useForm } from 'react-hook-form';
+import { useCheckNickname } from '@hooks/useGetQueries';
+import { usePatchNickname } from '@hooks/usePatchMutations';
+import { media } from '@styles/media';
+import styled from 'styled-components';
+import useDebounce from '@hooks/useDebounce';
+import Input from '@components/common/Input';
+import Button from '@components/common/Button';
+import placeholderImage from '@assets/images/placeholder-image.png';
+import ErrorMessage from '@components/common/ErrorMessage.tsx';
+import editLogo from '@assets/icons/edit.svg';
+import { logoutAtom, withdrawAtom } from '@atoms/authAtom';
+import { useSetAtom } from 'jotai';
+import { ModalContext } from '@context/ModalContext';
+import ResignModal from '@components/common/Modal/ResignModal';
+
+type FormValue = {
+  nickname: string;
+};
+
+type MyProfileProps = {
+  profileImg: string;
+  nickname: string;
+};
+
+const MyProfile = memo(({ profileImg, nickname }: MyProfileProps) => {
+  const [isEdit, setIsEdit] = useState<boolean>(false);
+  const methods = useForm<FormValue>({
+    defaultValues: {
+      nickname,
+    },
+    mode: 'onTouched',
+  });
+  const newNickname = methods.watch('nickname');
+  const debouncedNickname = useDebounce(newNickname, 200);
+  const { data: validate } = useCheckNickname(debouncedNickname, nickname);
+  const { mutate: updateNickname } = usePatchNickname();
+  const { openModal } = useContext(ModalContext);
+  const logout = useSetAtom(logoutAtom);
+  const withdraw = useSetAtom(withdrawAtom);
+
+  const handleWithdrawal = async () => {
+    const isWithdrawal = await openModal(<ResignModal />).catch(() => false);
+    if (isWithdrawal) withdraw();
+  };
+
+  const onSubmit = ({ nickname }: FormValue) => {
+    if (!validate) updateNickname(nickname);
+  };
+  return (
+    <FormProvider {...methods}>
+      <StyledSection>
+        <StyledSectionTitle>유저 정보</StyledSectionTitle>
+        <StyledContainer>
+          <StyledImg alt={nickname} src={profileImg ?? placeholderImage} />
+          {isEdit ? (
+            <StyledForm onSubmit={methods.handleSubmit(onSubmit)}>
+              <Input
+                label="닉네임"
+                placeholder="닉네임을 입력해주세요."
+                registerType="nickname"
+                required={true}
+                maxLength={8}
+              />
+              {validate && newNickname !== nickname ? (
+                <ErrorMessage type="duplicate" />
+              ) : null}
+              <StyledButtonContainer>
+                <StyledButtonWrapper>
+                  <Button
+                    text="취소"
+                    disabled={false}
+                    $colorType="error"
+                    onClick={() => setIsEdit(false)}
+                  />
+                  <Button
+                    type="submit"
+                    text="수정"
+                    disabled={
+                      newNickname === nickname ||
+                      validate ||
+                      nickname.length < 2
+                    }
+                  />
+                </StyledButtonWrapper>
+              </StyledButtonContainer>
+            </StyledForm>
+          ) : (
+            <StyledInfoContainer>
+              <StyledInfo>
+                <span>{nickname}</span>
+                <StyledLogo
+                  src={editLogo}
+                  alt="edit"
+                  onClick={() => setIsEdit(true)}
+                />
+              </StyledInfo>
+              <StyledButtonContainer>
+                <StyledButtonWrapper>
+                  <Button
+                    text="로그아웃"
+                    disabled={false}
+                    $colorType="light"
+                    onClick={() => logout()}
+                  />
+                  <Button
+                    text="회원탈퇴"
+                    disabled={false}
+                    $colorType="error"
+                    onClick={handleWithdrawal}
+                  />
+                </StyledButtonWrapper>
+              </StyledButtonContainer>
+            </StyledInfoContainer>
+          )}
+        </StyledContainer>
+      </StyledSection>
+    </FormProvider>
+  );
+});
+
+MyProfile.displayName = 'MyProfile';
+
+const StyledSection = styled.section`
+  max-width: 1140px;
+  width: 100%;
+  padding: 0 50px;
+  margin: 40px auto;
+  ${media.phone`
+    padding: 0 20px;
+  `}
+`;
+
+const StyledSectionTitle = styled.h2`
+  font-weight: bold;
+  font-size: 20px;
+  margin-bottom: 20px;
+`;
+
+const StyledContainer = styled.div`
+  display: flex;
+  justify-content: center;
+  gap: 15px;
+`;
+
+const StyledImg = styled.img`
+  width: 100px;
+  height: 100px;
+  overflow: hidden;
+  border-radius: 50%;
+  aspect-ratio: 1;
+`;
+
+const StyledInfoContainer = styled.div`
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+`;
+
+const StyledInfo = styled.div`
+  display: flex;
+  align-items: center;
+  gap: 8px;
+`;
+
+const StyledLogo = styled.img`
+  width: 20px;
+  height: 20px;
+  cursor: pointer;
+`;
+
+const StyledForm = styled.form`
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  width: 70%;
+  ${media.phone`
+    width: 50%;
+  `}
+`;
+
+const StyledButtonContainer = styled.div`
+  margin-top: 12px;
+  width: 100%;
+  display: flex;
+  justify-content: flex-end;
+`;
+
+const StyledButtonWrapper = styled.div`
+  display: flex;
+  gap: 12px;
+`;
+
+export default MyProfile;

--- a/frontend/src/components/search/HighlightText.tsx
+++ b/frontend/src/components/search/HighlightText.tsx
@@ -1,0 +1,33 @@
+import { memo } from 'react';
+import styled from 'styled-components';
+
+const HighlightText = memo(
+  ({
+    searchText,
+    searchResult,
+  }: {
+    searchText: string;
+    searchResult: string;
+  }) => {
+    const matchText = searchResult.split(new RegExp(`(${searchText})`, 'gi'));
+    console.log(matchText);
+    return (
+      <div>
+        {matchText.map((part, idx) => (
+          <StyledSpan key={idx} $highlight={idx === 1}>
+            {part}
+          </StyledSpan>
+        ))}
+      </div>
+    );
+  },
+);
+
+HighlightText.displayName = 'HighlightText';
+
+const StyledSpan = styled.span<{ $highlight: boolean }>`
+  color: ${({ $highlight }) =>
+    $highlight ? 'var(--primary)' : 'var(--black)'};
+`;
+
+export default HighlightText;

--- a/frontend/src/components/search/PreviewList.tsx
+++ b/frontend/src/components/search/PreviewList.tsx
@@ -3,52 +3,62 @@ import { ContentResponse } from 'src/@types/content';
 import styled from 'styled-components';
 import { Link } from 'react-router-dom';
 import searchIcon from '@assets/icons/search.svg';
+import HighlightText from '@components/search/HighlightText';
 
 type PreviewListProps = {
   contents: Omit<ContentResponse, 'comment'>[];
   talkContents: Omit<ContentResponse, 'comment'>[];
+  searchText: string;
 };
 
-const PreviewList = memo(({ contents, talkContents }: PreviewListProps) => {
-  if (!contents.length && !talkContents.length) {
-    return null;
-  }
+const PreviewList = memo(
+  ({ contents, talkContents, searchText }: PreviewListProps) => {
+    if (!contents.length && !talkContents.length) {
+      return null;
+    }
 
-  return (
-    <StyledPreviewContainer>
-      {contents.length > 0 && (
-        <StyledSection>
-          <StyledSearchSectionTitle>📸 덕질자랑</StyledSearchSectionTitle>
-          <ul>
-            {contents.map((content) => (
-              <Link to={`/article/${content.id}`} key={content.id}>
-                <StyledSearchList>
-                  <StyledSearchIcon src={searchIcon} />
-                  <span>{content.title}</span>
-                </StyledSearchList>
-              </Link>
-            ))}
-          </ul>
-        </StyledSection>
-      )}
-      {talkContents.length > 0 && (
-        <StyledSection>
-          <StyledSearchSectionTitle>🎙️ 덕질토크</StyledSearchSectionTitle>
-          <ul>
-            {talkContents.map((content) => (
-              <Link to={`/talk/${content.id}`} key={content.id}>
-                <StyledSearchList>
-                  <StyledSearchIcon src={searchIcon} />
-                  <span>{content.title}</span>
-                </StyledSearchList>
-              </Link>
-            ))}
-          </ul>
-        </StyledSection>
-      )}
-    </StyledPreviewContainer>
-  );
-});
+    return (
+      <StyledPreviewContainer>
+        {contents.length > 0 && (
+          <StyledSection>
+            <StyledSearchSectionTitle>📸 덕질자랑</StyledSearchSectionTitle>
+            <ul>
+              {contents.map((content) => (
+                <Link to={`/article/${content.id}`} key={content.id}>
+                  <StyledSearchList>
+                    <StyledSearchIcon alt="search" src={searchIcon} />
+                    <HighlightText
+                      searchText={searchText}
+                      searchResult={content.title}
+                    />
+                  </StyledSearchList>
+                </Link>
+              ))}
+            </ul>
+          </StyledSection>
+        )}
+        {talkContents.length > 0 && (
+          <StyledSection>
+            <StyledSearchSectionTitle>🎙️ 덕질토크</StyledSearchSectionTitle>
+            <ul>
+              {talkContents.map((content) => (
+                <Link to={`/talk/${content.id}`} key={content.id}>
+                  <StyledSearchList>
+                    <StyledSearchIcon alt="search" src={searchIcon} />
+                    <HighlightText
+                      searchText={searchText}
+                      searchResult={content.title}
+                    />
+                  </StyledSearchList>
+                </Link>
+              ))}
+            </ul>
+          </StyledSection>
+        )}
+      </StyledPreviewContainer>
+    );
+  },
+);
 
 PreviewList.displayName = 'PreviewList';
 

--- a/frontend/src/components/talk/EditTalk/DukpoolEditTalk.tsx
+++ b/frontend/src/components/talk/EditTalk/DukpoolEditTalk.tsx
@@ -64,10 +64,10 @@ const DukpoolEditTalk = memo(() => {
           placeholder="제목을 입력해주세요."
           registerType="title"
           required={true}
-          minLength={5}
+          minLength={2}
         />
         {titleErrorState && (
-          <ErrorMessage field="제목" type={titleErrorState.type} length={5} />
+          <ErrorMessage field="제목" type={titleErrorState.type} length={2} />
         )}
         <Tags />
         <TextArea
@@ -83,12 +83,7 @@ const DukpoolEditTalk = memo(() => {
         <Images />
         <StyledButtonContainer>
           <StyledButtonWrapper>
-            <Button
-              type="submit"
-              text="등록"
-              disabled={false}
-              $colorType="dark"
-            />
+            <Button type="submit" text="등록" disabled={false} />
           </StyledButtonWrapper>
         </StyledButtonContainer>
       </form>

--- a/frontend/src/components/talk/TalkCard/MyTalkCard.tsx
+++ b/frontend/src/components/talk/TalkCard/MyTalkCard.tsx
@@ -18,7 +18,10 @@ const MyTalkCard = memo(({ nickname, profileImg, data }: MyTalkCardProps) => {
       <StyledLink to={`/talk/${data.id}`}>
         <StyledContainer>
           <StyledImgContainer>
-            <StyledImage src={data.img[0] ?? placeholderImage} />
+            <StyledImage
+              alt={data.title}
+              src={data.img[0] ?? placeholderImage}
+            />
           </StyledImgContainer>
           <StyledContentContainer>
             <StyledTitle>{data.title}</StyledTitle>
@@ -29,7 +32,10 @@ const MyTalkCard = memo(({ nickname, profileImg, data }: MyTalkCardProps) => {
           <StyledProfileContainer>
             <StyledProfileDiv>
               <StyledProfileImageContainer>
-                <StyledProfileImage src={profileImg ?? placeholderImage} />
+                <StyledProfileImage
+                  alt={nickname}
+                  src={profileImg ?? placeholderImage}
+                />
               </StyledProfileImageContainer>
               <StyledProfile>{nickname}</StyledProfile>
             </StyledProfileDiv>
@@ -93,7 +99,7 @@ const StyledContentContainer = styled.div`
 const StyledContent = styled.div`
   width: 100%;
   line-height: 1.36;
-  font-size: 13px;
+  font-size: 12px;
   text-overflow: ellipsis;
   overflow: hidden;
   word-break: break-word;
@@ -103,7 +109,7 @@ const StyledContent = styled.div`
 `;
 
 const StyledTitle = styled.h3`
-  font-size: 18px;
+  font-size: 16px;
   margin-bottom: 8px;
   text-overflow: ellipsis;
   overflow: hidden;

--- a/frontend/src/components/talk/TalkCard/index.tsx
+++ b/frontend/src/components/talk/TalkCard/index.tsx
@@ -22,7 +22,7 @@ const TalkCard = memo(
         <StyledLink to={`/talk/${id}`}>
           <StyledContainer>
             <StyledImgContainer>
-              <StyledImage src={img[0] ?? placeholderImage} />
+              <StyledImage alt={title} src={img[0] ?? placeholderImage} />
             </StyledImgContainer>
             <StyledContentContainer>
               <StyledTitle>{title}</StyledTitle>
@@ -34,6 +34,7 @@ const TalkCard = memo(
               <StyledProfileDiv>
                 <StyledProfileImageContainer>
                   <StyledProfileImage
+                    alt={writer.nickname}
                     src={writer.profileImg ?? placeholderImage}
                   />
                 </StyledProfileImageContainer>
@@ -100,7 +101,7 @@ const StyledContentContainer = styled.div`
 const StyledContent = styled.div`
   width: 100%;
   line-height: 1.36;
-  font-size: 13px;
+  font-size: 12px;
   text-overflow: ellipsis;
   overflow: hidden;
   word-break: break-word;
@@ -110,7 +111,7 @@ const StyledContent = styled.div`
 `;
 
 const StyledTitle = styled.h3`
-  font-size: 18px;
+  font-size: 16px;
   margin-bottom: 8px;
   text-overflow: ellipsis;
   overflow: hidden;

--- a/frontend/src/components/talk/TalkDetail/TalkCommentItem.tsx
+++ b/frontend/src/components/talk/TalkDetail/TalkCommentItem.tsx
@@ -52,6 +52,7 @@ const TalkCommentItem = memo(
             <StyledCommentUserProfileContainer>
               <StyledCommentProfileImgContainer>
                 <StyledCommentProfileImg
+                  alt={writer.nickname}
                   src={writer.profileImg ?? placeholderImage}
                 />
               </StyledCommentProfileImgContainer>

--- a/frontend/src/components/talk/TalkDetail/TalkDescription.tsx
+++ b/frontend/src/components/talk/TalkDetail/TalkDescription.tsx
@@ -50,7 +50,10 @@ const TalkDescription = memo(
           <StyledUserProfileContainer>
             <StyledUserProfile>
               <StyledProfileImgContainer>
-                <StyledProfileImg src={writer.profileImg ?? placeholderImage} />
+                <StyledProfileImg
+                  alt={writer.nickname}
+                  src={writer.profileImg ?? placeholderImage}
+                />
               </StyledProfileImgContainer>
               <StyledProfileName>{writer.nickname}</StyledProfileName>
             </StyledUserProfile>

--- a/frontend/src/components/talk/TalkDetail/index.tsx
+++ b/frontend/src/components/talk/TalkDetail/index.tsx
@@ -11,7 +11,7 @@ const TalkDetail = () => {
   const { data } = useTalk(talkId);
   return (
     <>
-      <PostImage images={data.img} />
+      <PostImage title={data.title} images={data.img} />
       <TalkDescription {...data} />
       <TalkComment contentId={data.id} comments={data.comment} />
     </>

--- a/frontend/src/constants/sliderOption.tsx
+++ b/frontend/src/constants/sliderOption.tsx
@@ -6,13 +6,13 @@ import { media } from '@styles/media';
 
 const ArrowLeft = ({ currentSlide, slideCount, ...props }: any) => (
   <StyledLeftArrowImgContainer {...props}>
-    <StyledImg src={prev} />
+    <StyledImg alt="arrow" src={prev} />
   </StyledLeftArrowImgContainer>
 );
 
 const ArrowRight = ({ currentSlide, slideCount, ...props }: any) => (
   <StyledRightArrowImgContainer {...props}>
-    <StyledImg src={next} />
+    <StyledImg alt="arrow" src={next} />
   </StyledRightArrowImgContainer>
 );
 

--- a/frontend/src/pages/Kakao.tsx
+++ b/frontend/src/pages/Kakao.tsx
@@ -20,7 +20,7 @@ const Kakao = () => {
   return (
     <Layout>
       <StyledContainer $height={height}>
-        <StyledLogo src={Logo} alt="DukpoolLogo" />
+        <StyledLogo src={Logo} alt="Dukpool Logo" />
       </StyledContainer>
     </Layout>
   );

--- a/frontend/src/pages/Login.tsx
+++ b/frontend/src/pages/Login.tsx
@@ -10,7 +10,7 @@ const Login = () => {
     <Layout>
       <StyledContainer $height={height}>
         <StyledInfo>
-          <StyledLogo src={Logo} alt="Dukpool 로고" />
+          <StyledLogo src={Logo} alt="Dukpool Logo" />
           <StyledInfoText>나만의 덕질 취향을 공유해보세요.</StyledInfoText>
         </StyledInfo>
         <KakaoLoginButton />

--- a/frontend/src/pages/NewArticle.tsx
+++ b/frontend/src/pages/NewArticle.tsx
@@ -50,9 +50,9 @@ const NewArticle = () => {
               placeholder="제목을 입력해주세요."
               registerType="title"
               required={true}
-              minLength={5}
+              minLength={2}
             />
-            {<ErrorMessage field="제목" type={title?.type!} length={5} />}
+            {<ErrorMessage field="제목" type={title?.type!} length={2} />}
             <Tags />
             <TextArea
               label="내용"
@@ -65,12 +65,7 @@ const NewArticle = () => {
             <Images />
             <StyledButtonContainer>
               <StyledButtonWrapper>
-                <Button
-                  type="submit"
-                  text="등록"
-                  disabled={false}
-                  $colorType="dark"
-                />
+                <Button type="submit" text="등록" disabled={false} />
               </StyledButtonWrapper>
             </StyledButtonContainer>
           </StyledForm>

--- a/frontend/src/pages/NewTalk.tsx
+++ b/frontend/src/pages/NewTalk.tsx
@@ -49,9 +49,9 @@ const NewTalk = () => {
               placeholder="제목을 입력해주세요."
               registerType="title"
               required={true}
-              minLength={5}
+              minLength={2}
             />
-            {<ErrorMessage field="제목" type={title?.type!} length={5} />}
+            {<ErrorMessage field="제목" type={title?.type!} length={2} />}
             <Tags />
             <TextArea
               label="내용"
@@ -64,12 +64,7 @@ const NewTalk = () => {
             <Images />
             <StyledButtonContainer>
               <StyledButtonWrapper>
-                <Button
-                  type="submit"
-                  text="등록"
-                  disabled={false}
-                  $colorType="dark"
-                />
+                <Button type="submit" text="등록" disabled={false} />
               </StyledButtonWrapper>
             </StyledButtonContainer>
           </StyledForm>

--- a/frontend/src/pages/NotFound.tsx
+++ b/frontend/src/pages/NotFound.tsx
@@ -15,13 +15,12 @@ const NotFound = () => {
     <Layout>
       <StyledWrapper $height={height}>
         <StyledInfo>
-          <StyledLogo src={Logo} alt="Dukpool 로고" />
+          <StyledLogo src={Logo} alt="Dukpool Logo" />
           <StyledParagraph>요청하신 페이지를 찾을 수 없습니다.</StyledParagraph>
         </StyledInfo>
         <Button
           text="메인 페이지로 돌아가기"
           disabled={false}
-          $colorType="dark"
           onClick={goToMainPage}
         />
       </StyledWrapper>

--- a/frontend/src/styles/base.ts
+++ b/frontend/src/styles/base.ts
@@ -21,11 +21,11 @@ const base = css`
   }
   * {
     color: var(--black);
-    font-family: 'Netmarble';
+    font-family: 'TheJamsil';
     font-weight: 500;
   }
   #root {
-    font-family: 'Netmarble';
+    font-family: 'TheJamsil';
   }
   body {
     margin: auto;

--- a/frontend/src/styles/font.css
+++ b/frontend/src/styles/font.css
@@ -1,32 +1,32 @@
 @font-face {
-  font-family: 'Netmarble';
-  font-weight: 500;
+  font-family: 'TheJamsil';
+  font-weight: 400;
   font-style: normal;
-  src: url('https://cdn.jsdelivr.net/gh/webfontworld/netmarble/NetmarbleMedium.eot');
+  src: url('https://cdn.jsdelivr.net/gh/webfontworld/TheJamsil/TheJamsil-Regular.eot');
   src:
-    url('https://cdn.jsdelivr.net/gh/webfontworld/netmarble/NetmarbleMedium.eot?#iefix')
+    url('https://cdn.jsdelivr.net/gh/webfontworld/TheJamsil/TheJamsil-Regular.eot?#iefix')
       format('embedded-opentype'),
-    url('https://cdn.jsdelivr.net/gh/webfontworld/netmarble/NetmarbleMedium.woff2')
+    url('https://cdn.jsdelivr.net/gh/webfontworld/TheJamsil/TheJamsil-Regular.woff2')
       format('woff2'),
-    url('https://cdn.jsdelivr.net/gh/webfontworld/netmarble/NetmarbleMedium.woff')
+    url('https://cdn.jsdelivr.net/gh/webfontworld/TheJamsil/TheJamsil-Regular.woff')
       format('woff'),
-    url('https://cdn.jsdelivr.net/gh/webfontworld/netmarble/NetmarbleMedium.ttf')
+    url('https://cdn.jsdelivr.net/gh/webfontworld/TheJamsil/TheJamsil-Regular.ttf')
       format('truetype');
   font-display: swap;
 }
 @font-face {
-  font-family: 'Netmarble';
+  font-family: 'TheJamsil';
   font-weight: 700;
   font-style: normal;
-  src: url('https://cdn.jsdelivr.net/gh/webfontworld/netmarble/NetmarbleBold.eot');
+  src: url('https://cdn.jsdelivr.net/gh/webfontworld/TheJamsil/TheJamsil-Bold.eot');
   src:
-    url('https://cdn.jsdelivr.net/gh/webfontworld/netmarble/NetmarbleBold.eot?#iefix')
+    url('https://cdn.jsdelivr.net/gh/webfontworld/TheJamsil/TheJamsil-Bold.eot?#iefix')
       format('embedded-opentype'),
-    url('https://cdn.jsdelivr.net/gh/webfontworld/netmarble/NetmarbleBold.woff2')
+    url('https://cdn.jsdelivr.net/gh/webfontworld/TheJamsil/TheJamsil-Bold.woff2')
       format('woff2'),
-    url('https://cdn.jsdelivr.net/gh/webfontworld/netmarble/NetmarbleBold.woff')
+    url('https://cdn.jsdelivr.net/gh/webfontworld/TheJamsil/TheJamsil-Bold.woff')
       format('woff'),
-    url('https://cdn.jsdelivr.net/gh/webfontworld/netmarble/NetmarbleBold.ttf')
+    url('https://cdn.jsdelivr.net/gh/webfontworld/TheJamsil/TheJamsil-Bold.ttf')
       format('truetype');
   font-display: swap;
 }


### PR DESCRIPTION
- refreshToken을 통한 accessToken 재발급 로직을 수정했습니다.
- accessToken 및 refreshToken 만료시에 에러처리를 수정했습니다.
- 내정보 페이지 유저 로그아웃 및 회원탈퇴 기능을 추가했습니다.
- 애플리케이션 img의 전체적인 alt 어트리뷰트를 추가했습니다.
- 버튼 컴포넌트의 props를 수정했습니다.
- navbar의 로그인 유무에 따른 렌더링 분기처리를 수정했습니다.
- 검색 결과 미리보기의 글자 하이라이팅을 구현했습니다.
- 애플리케이션의 폰트를 교체했습니다.

close #55 